### PR TITLE
enhancement/166551379/invert blue items

### DIFF
--- a/src/components/atoms/Logout/Logout.jsx
+++ b/src/components/atoms/Logout/Logout.jsx
@@ -3,7 +3,7 @@ import { NavLink } from '..'
 
 const Logout = () => {
   return (
-    <NavLink path='/logout'>Logout</NavLink>
+    <NavLink path='/logout' className="logout-btn">Logout</NavLink>
   )
 }
 

--- a/src/components/atoms/Logout/Logout.jsx
+++ b/src/components/atoms/Logout/Logout.jsx
@@ -3,7 +3,7 @@ import { NavLink } from '..'
 
 const Logout = () => {
   return (
-    <NavLink path='/logout' className="logout-btn">Logout</NavLink>
+    <NavLink path='/logout' className='logout-btn'>Logout</NavLink>
   )
 }
 

--- a/src/components/molecules/Darkmode/DarkmodeContainer.jsx
+++ b/src/components/molecules/Darkmode/DarkmodeContainer.jsx
@@ -33,6 +33,8 @@ export default compose(
         .loader {background-color: black; filter: invert(100%);}
         .file-tree-map-section a.not-active { color: #aeb3b8 !important;}
         a.link.bold.parent-link { color: #000 !important;}
+        a.logout-btn.nav-link:hover { color: #fff !important; }
+        .inputfile .file-upload:hover { color: #00caff !important; border: 1px solid #00caff !important;}
       `
       }
     }

--- a/src/components/molecules/Darkmode/DarkmodeContainer.jsx
+++ b/src/components/molecules/Darkmode/DarkmodeContainer.jsx
@@ -21,8 +21,18 @@ export default compose(
         cssStyles: `
         .content-wrapper { filter: invert(90%) contrast(120%) brightness(135%);}
         li.page-item { filter: invert(90%)}
+        a.nav-link:hover, a.nav-link.active, a.link, .side-menu-section .nav-link:hover, .side-menu-section .nav-link.active { color: #00caff !important; }
+        li.active.pointer.nav-item { color: #00caff; border-left: 3px #00caff solid !important;}
+        i#Tooltip-delete-item-icon { color: #00caff !important;}
+        div.Select-option.is-focused {background-color:  rgba(0,202,252,0.25) !important;}
+        div.Select-option.is-selected {background-color: rgba(0,202,252,0.4) !important;}
+        .Select-control:active {border-color: #00caff !important; box-shadow: 0 0 0 0.2rem rgba(0,202,252,0.25) !important;}
+        input.field-group .form-control:focus, .field-group .form-control:active { border-color: #00caff !important;}
+        .field-group .form-control:focus { border-color: #00caff !important; box-shadow: 0 0 0 0.2rem rgba(0,202,252,0.25)}
         .avatar, video, button, .body-template img, .file-editor { filter: invert(100%);}
         .loader {background-color: black; filter: invert(100%);}
+        .file-tree-map-section a.not-active { color: #aeb3b8 !important;}
+        a.link.bold.parent-link { color: #000 !important;}
       `
       }
     }

--- a/src/components/molecules/Darkmode/DarkmodeContainer.jsx
+++ b/src/components/molecules/Darkmode/DarkmodeContainer.jsx
@@ -24,8 +24,8 @@ export default compose(
         a.nav-link:hover, a.nav-link.active, a.link, .side-menu-section .nav-link:hover, .side-menu-section .nav-link.active { color: #00caff !important; }
         li.active.pointer.nav-item { color: #00caff; border-left: 3px #00caff solid !important;}
         i#Tooltip-delete-item-icon { color: #00caff !important;}
-        div.Select-option.is-focused {background-color:  rgba(0,202,252,0.25) !important;}
-        div.Select-option.is-selected {background-color: rgba(0,202,252,0.4) !important;}
+        div.content-wrapper div.Select-option.is-focused {background-color:  rgba(0,202,252,0.25) !important;}
+        div.content-wrapper div.Select-option.is-selected {background-color: rgba(0,202,252,0.4) !important;}
         .Select-control:active {border-color: #00caff !important; box-shadow: 0 0 0 0.2rem rgba(0,202,252,0.25) !important;}
         input.field-group .form-control:focus, .field-group .form-control:active { border-color: #00caff !important;}
         .field-group .form-control:focus { border-color: #00caff !important; box-shadow: 0 0 0 0.2rem rgba(0,202,252,0.25)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Get rid of bright blue elements in while Darkmode is active.
## Description
<!--- Describe your changes in detail -->
When darkmode activates, change the color of Houndstooth Orange items to it's inverted blue counterpart. So that when Darkmode runs it's invert on the body, all the elements remain orange rather than blue.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to associated pivotal bug/feature ticket. -->
https://www.pivotaltracker.com/story/show/166551379
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

1. [x] I have requested at least one person to review this PR.
2. [x] I have assigned this PR to the person responsible for these changes (usually you!)
3. [x] I have added appropriate label(s) to this PR (i.e. enhancement, bug etc.)
4. [ ] I have added the WIP label if this PR is a work in progess
5. [ ] I have removed the WIP label and addded a migration priority if PR is ready for merge