### PR TITLE
Flatten cached repos to 2 essential keys

### DIFF
--- a/src/components/organisms/RepoSelect/RepoSelectContainer.jsx
+++ b/src/components/organisms/RepoSelect/RepoSelectContainer.jsx
@@ -24,8 +24,13 @@ export default compose(
           .then(({ repos }) => {
             if (repos) {
               setLoadingRepos(false)
-              storage.set('all_repos', repos)
-              setAsyncRepoList(repos)
+              const flattenedRepos = []
+              repos.forEach(repo => {
+                let flattenedRepo = Object.assign({}, {'default_branch': repo['default_branch'], 'full_name': repo['full_name']})
+                flattenedRepos.push(flattenedRepo)
+              })
+              storage.set('all_repos', flattenedRepos)
+              setAsyncRepoList(flattenedRepos)
             }
           })
           .catch((resp) => {

--- a/src/components/organisms/RepoSelect/RepoSelectContainer.jsx
+++ b/src/components/organisms/RepoSelect/RepoSelectContainer.jsx
@@ -25,10 +25,9 @@ export default compose(
             if (repos) {
               setLoadingRepos(false)
               const flattenedRepos = []
-              repos.forEach(repo => {
-                let flattenedRepo = Object.assign({}, {'default_branch': repo['default_branch'], 'full_name': repo['full_name']})
-                flattenedRepos.push(flattenedRepo)
-              })
+              for (let i=0; i<repos.length; i++) {
+                flattenedRepos.push(Object.assign({}, {'default_branch': repos[i]['default_branch'], 'full_name': repos[i]['full_name']}))
+              }
               storage.set('all_repos', flattenedRepos)
               setAsyncRepoList(flattenedRepos)
             }

--- a/src/components/organisms/RepoSelect/RepoSelectContainer.jsx
+++ b/src/components/organisms/RepoSelect/RepoSelectContainer.jsx
@@ -25,7 +25,7 @@ export default compose(
             if (repos) {
               setLoadingRepos(false)
               const flattenedRepos = []
-              for (let i=0; i<repos.length; i++) {
+              for (let i = 0; i < repos.length; i++) {
                 flattenedRepos.push(Object.assign({}, {'default_branch': repos[i]['default_branch'], 'full_name': repos[i]['full_name']}))
               }
               storage.set('all_repos', flattenedRepos)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Flatten repos for search feature prior to saving to local storage, using the only 2 essential key/value pairs: 'default_branch' and 'full_name.'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes local storage cache error when user has access to an extremely high number of repos (i.e. over 100,000).
<!--- Link to associated pivotal bug/feature ticket. -->
https://www.pivotaltracker.com/story/show/166677817

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally using my Github account, which has access to over 140,000 repos.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

1. [x] I have requested at least one person to review this PR.
2. [x] I have assigned this PR to the person responsible for these changes (usually you!)
3. [x] I have added appropriate label(s) to this PR (i.e. enhancement, bug etc.)
4. [ ] I have added the WIP label if this PR is a work in progess
5. [ ] I have removed the WIP label and addded a migration priority if PR is ready for merge